### PR TITLE
Test Orphaned Migration Detection in GitHub Actions

### DIFF
--- a/.github/workflows/migration-guard.yml
+++ b/.github/workflows/migration-guard.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   pull-requests: write  # Required for commenting on PRs
+  issues: write  # Also needed for PR comments via GitHub API
 
 jobs:
   migration-check:

--- a/.github/workflows/migration-guard.yml
+++ b/.github/workflows/migration-guard.yml
@@ -51,6 +51,14 @@ jobs:
         run: |
           bundle exec rails db:create
           bundle exec rails db:schema:load
+          
+      - name: Run pending migrations (if any)
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/migration_guard_test
+          RAILS_ENV: development
+        run: |
+          echo "Running any pending migrations to detect orphaned ones..."
+          bundle exec rails db:migrate || true
 
       - name: Run Migration Guard Check
         id: migration_check

--- a/.github/workflows/migration-guard.yml
+++ b/.github/workflows/migration-guard.yml
@@ -32,6 +32,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for branch comparison
+          
+      - name: Setup git branches
+        run: |
+          git fetch origin main:main || true
+          git branch --list
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -42,7 +47,7 @@ jobs:
       - name: Setup database
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/migration_guard_test
-          RAILS_ENV: test
+          RAILS_ENV: development
         run: |
           bundle exec rails db:create
           bundle exec rails db:schema:load
@@ -51,7 +56,7 @@ jobs:
         id: migration_check
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/migration_guard_test
-          RAILS_ENV: test
+          RAILS_ENV: development
           FORMAT: json
         run: |
           echo "Running migration guard check..."

--- a/.github/workflows/migration-guard.yml
+++ b/.github/workflows/migration-guard.yml
@@ -7,6 +7,10 @@ on:
     branches: [main, develop]
   workflow_dispatch:  # Allow manual triggering for testing
 
+permissions:
+  contents: read
+  pull-requests: write  # Required for commenting on PRs
+
 jobs:
   migration-check:
     name: Check for Orphaned Migrations

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This README would normally document whatever steps are necessary to get the
 application up and running.
 
+## Testing Rails Migration Guard
+
+This app is used to test the rails-migration-guard gem with GitHub Actions integration.
+
 Things you may want to cover:
 
 * Ruby version

--- a/db/migrate/20250617214330_add_orphaned_feature.rb
+++ b/db/migrate/20250617214330_add_orphaned_feature.rb
@@ -1,0 +1,9 @@
+class AddOrphanedFeature < ActiveRecord::Migration[8.0]
+  def change
+    create_table :orphaned_features do |t|
+      t.string :name
+      t.text :description
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250618020646_add_test_field_to_users.rb
+++ b/db/migrate/20250618020646_add_test_field_to_users.rb
@@ -1,0 +1,5 @@
+class AddTestFieldToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :test_field, :string
+  end
+end

--- a/pr9-artifacts/migration-check-results/migration_check.json
+++ b/pr9-artifacts/migration-check-results/migration_check.json
@@ -1,0 +1,116 @@
+{
+  "migration_guard": {
+    "version": "0.1.0",
+    "status": "warning",
+    "summary": {
+      "total_orphaned": 0,
+      "total_missing": 13,
+      "issues_found": 13,
+      "main_branch": "main",
+      "current_branch": "HEAD"
+    },
+    "orphaned_migrations": [],
+    "missing_migrations": [
+      {
+        "version": "20250617000634",
+        "file": "20250617000634_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617045645",
+        "file": "20250617045645_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617045710",
+        "file": "20250617045710_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617045827",
+        "file": "20250617045827_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617045958",
+        "file": "20250617045958_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617050016",
+        "file": "20250617050016_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617121536",
+        "file": "20250617121536_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212028",
+        "file": "20250617212028_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212029",
+        "file": "20250617212029_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212030",
+        "file": "20250617212030_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212104",
+        "file": "20250617212104_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212230",
+        "file": "20250617212230_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212231",
+        "file": "20250617212231_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      }
+    ],
+    "branch_info": {
+      "current": "HEAD",
+      "main": "main",
+      "ahead_count": 0,
+      "behind_count": 0
+    },
+    "timestamp": "2025-06-17T16:45:42-05:00",
+    "exit_code": 1,
+    "strictness": "warning"
+  }
+}

--- a/pr9-final/migration-check-results/migration_check.json
+++ b/pr9-final/migration-check-results/migration_check.json
@@ -1,0 +1,124 @@
+{
+  "migration_guard": {
+    "version": "0.1.0",
+    "status": "warning",
+    "summary": {
+      "total_orphaned": 1,
+      "total_missing": 13,
+      "issues_found": 14,
+      "main_branch": "main",
+      "current_branch": "HEAD"
+    },
+    "orphaned_migrations": [
+      {
+        "version": "20250617214330",
+        "file": "20250617214330_*.rb",
+        "branch": "HEAD",
+        "author": "unknown",
+        "created_at": "2025-06-17T16:47:43-05:00"
+      }
+    ],
+    "missing_migrations": [
+      {
+        "version": "20250617000634",
+        "file": "20250617000634_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617045645",
+        "file": "20250617045645_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617045710",
+        "file": "20250617045710_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617045827",
+        "file": "20250617045827_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617045958",
+        "file": "20250617045958_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617050016",
+        "file": "20250617050016_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617121536",
+        "file": "20250617121536_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212028",
+        "file": "20250617212028_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212029",
+        "file": "20250617212029_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212030",
+        "file": "20250617212030_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212104",
+        "file": "20250617212104_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212230",
+        "file": "20250617212230_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      },
+      {
+        "version": "20250617212231",
+        "file": "20250617212231_*.rb",
+        "branch": "main",
+        "author": "unknown",
+        "created_at": null
+      }
+    ],
+    "branch_info": {
+      "current": "HEAD",
+      "main": "main",
+      "ahead_count": 0,
+      "behind_count": 0
+    },
+    "timestamp": "2025-06-17T16:47:45-05:00",
+    "exit_code": 1,
+    "strictness": "warning"
+  }
+}


### PR DESCRIPTION
## Purpose

This PR demonstrates proper orphaned migration detection by Migration Guard in GitHub Actions.

## What's in this PR

- **Orphaned Migration**: `AddOrphanedFeature` migration that creates a new table
- **README Update**: Minor documentation update
- **Workflow Fix**: Ensures development environment is used where Migration Guard is enabled

## Expected Behavior

The Migration Guard Check workflow should:
1. ✅ Detect the orphaned migration `20250617214330_add_orphaned_feature.rb`
2. ✅ Comment on this PR with a warning about the orphaned migration
3. ✅ Set exit code to 1 (warning)
4. ✅ Upload JSON results as artifacts

## Migration Details

The orphaned migration creates a new `orphaned_features` table with:
- name (string)
- description (text)
- timestamps

This simulates a common scenario where a developer creates a migration on their feature branch that hasn't been merged to main yet.